### PR TITLE
Update for stable rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.uwsgi_plugins_builder/
+target/
+Cargo.lock
+*.so

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+
+name = "uwsgi_rust"
+version = "0.0.1-dev"
+authors = ["Unbit s.a.s"]
+license = "MIT"
+repository = "https://github.com/unbit/uwsgi-rust"
+description = """
+uWSGI and Rust integration plugin. 
+"""
+
+[lib]
+crate-type = ["staticlib"]
+name = "uwsgi_rust"
+path = "plugin.rs"
+
+[dependencies]
+libc = "0.1"
+dylib = "0.0.1"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This plugin is an experimental effort to support Rust runtime into uWSGI.
 
 Consider it a proof of concept.
 
-To build (and use) the plugin you need a rust environment (>= 1.0.0-alpha) installed (the rustc binary must be in the system PATH)
+To build (and use) the plugin you need at least a rust-1.x stable environment installed (rustc/cargo binaries must be in the system PATH)
 
 Installation
 ------------
@@ -31,37 +31,35 @@ Usage
 Currently uWSGI expects Rust apps to be managed as shared/dynamic libraries:
 
 ```rust
-#![crate_type = "dylib"]
-#![feature(collections)] 
-
 use std::collections::HashMap;
 
 #[no_mangle]
 pub extern fn application(environ: HashMap<&str, &str>) -> (String, Vec<(String, String)>, Vec<Vec<u8>>) {
 
-	for (k, v) in environ.iter() {
-		println!("{} = {}", *k, *v);
-	}
+        for (k, v) in environ.iter() {
+                println!("{} = {}", *k, *v);
+        }
 
         let mut v = vec![];
-        v.push((String::from_str("Content-Type"), String::from_str("text/plain")));
-        v.push((String::from_str("Foo"), String::from_str("Bar")));
+        v.push((String::from("Content-Type"), String::from("text/plain")));
+        v.push((String::from("Foo"), String::from("Bar")));
 
         let mut body = vec![];
 
-        body.push(String::from_str("Hello").into_bytes());
+        body.push(String::from("Hello").into_bytes());
 
-        return (String::from_str("200 OK"), v, body);
+        return (String::from("200 OK"), v, body);
 }
+
 ```
 
 running
 
 ```sh
-rustc app.rs
+cargo build --release --manifest-path examples/Cargo.toml
 ```
 
-will result in libapp.so/libapp.dylib
+will result in `librust_uwsgi_app.so` under `examples/target/release/`
 
 This new library can be loaded in the uWSGI core with the standard `--dlopen` option. Finally you only need to tell uWSGI which rust function to execute ('application' in this case) at every request:
 
@@ -72,7 +70,7 @@ plugin = rust
 ; bind to http port 8080
 http-socket = :8080
 ; load the library app
-dlopen = ./libapp.so
+dlopen = ./examples/target/release/librust_uwsgi_app.so
 ; set 'application' as the entry point
 rust-fn = application
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+
+name = "rust_uwsgi_app"
+version = "0.0.1-dev"
+authors = ["Unbit s.a.s"]
+license = "MIT"
+repository = "https://github.com/unbit/uwsgi-rust"
+description = """
+An example app to be deployed on uwsgi-rust. 
+"""
+
+[lib]
+crate-type = ["dylib"]
+name = "rust_uwsgi_app"
+path = "app.rs"
+
+[dependencies]
+libc = "0.1"
+dylib = "0.0.1"

--- a/examples/app.rs
+++ b/examples/app.rs
@@ -1,6 +1,3 @@
-#![crate_type = "dylib"]
-#![feature(collections)] 
-
 use std::collections::HashMap;
 
 #[no_mangle]
@@ -11,12 +8,12 @@ pub extern fn application(environ: HashMap<&str, &str>) -> (String, Vec<(String,
 	}
 
         let mut v = vec![];
-        v.push((String::from_str("Content-Type"), String::from_str("text/plain")));
-        v.push((String::from_str("Foo"), String::from_str("Bar")));
+        v.push((String::from("Content-Type"), String::from("text/plain")));
+        v.push((String::from("Foo"), String::from("Bar")));
 
         let mut body = vec![];
 
-        body.push(String::from_str("Hello").into_bytes());
+        body.push(String::from("Hello").into_bytes());
 
-        return (String::from_str("200 OK"), v, body);
+        return (String::from("200 OK"), v, body);
 }

--- a/plugin.rs
+++ b/plugin.rs
@@ -1,14 +1,13 @@
-#![feature(libc)]
 #![allow(unused_mut)]
-#![feature(std_misc)]
 
+extern crate dylib;
 extern crate libc;
 
+use dylib::DynamicLibrary;
 use libc::c_void;
 use std::collections::HashMap;
 use std::str;
 use std::slice;
-use std::dynamic_lib::DynamicLibrary;
 
 // global access to the function entry point (could become a vector to support multple apps)
 static mut app : Option<extern fn(HashMap<&str, &str>) -> (String, Vec<(String, String)>, Vec<Vec<u8>>)> = None;

--- a/uwsgiplugin.py
+++ b/uwsgiplugin.py
@@ -5,13 +5,15 @@ import inspect
 base_path = os.path.dirname(inspect.getframeinfo(inspect.currentframe())[0])
 
 NAME = 'rust'
-GCC_LIST = ['rust', '%s/plugin.a' % base_path]
+GCC_LIST = ['rust', '%s/target/release/libuwsgi_rust.a' % base_path]
 
 CFLAGS = []
 
 if os.uname()[0] == 'Darwin':
     CFLAGS.append('-mmacosx-version-min=10.7')
 
-
-if os.system("rustc -o %s/plugin.a --crate-type staticlib %s/plugin.rs" % (base_path, base_path)) != 0:
+if os.system("cargo build --release") != 0:
     os._exit(1)
+
+# To also build the example app:
+#os.system("cargo build --release --manifest-path examples/Cargo.toml")


### PR DESCRIPTION
Rust is now providing stable channels for rustc and cargo. This PR contains several code and build-machinery changes to build with a recent rust-stable release, only using stable features, and using cargo to fetch/build dependencies.

Tested on a debian unstable with uwsgi-2.0 and rust-1.1 stable binaries:

```
uwsgi                                 2.0.7
rustc                                 1.1.0
cargo                                 0.3.0
```

Signed-off-by: Luca Bruno lucab@debian.org
